### PR TITLE
add options to generateJSON to preserve `\t` char

### DIFF
--- a/packages/html/src/generateJSON.ts
+++ b/packages/html/src/generateJSON.ts
@@ -2,9 +2,9 @@ import { Extensions, getSchema } from '@tiptap/core'
 import { DOMParser } from '@tiptap/pm/model'
 import { parseHTML } from 'zeed-dom'
 
-export function generateJSON(html: string, extensions: Extensions): Record<string, any> {
+export function generateJSON(html: string, extensions: Extensions, options?: any): Record<string, any> {
   const schema = getSchema(extensions)
   const dom = parseHTML(html) as unknown as Node
 
-  return DOMParser.fromSchema(schema).parse(dom).toJSON()
+  return DOMParser.fromSchema(schema).parse(dom, options).toJSON()
 }


### PR DESCRIPTION
Change to allow caller of `generateJSON` to pass an optional `options` object which can contain `preserveWhitespace:1` to preserve `\t` characters inside text nodes.

Example:

```
converterExtensions = [
    Document,
    Paragraph,
    Text,
    [...],
}
const json = generateJSON(html, converterExtensions, {preserveWhitespace:1})
```